### PR TITLE
fix undefined reference omap_fb_reserve_memblock

### DIFF
--- a/arch/arm/mach-omap2/common.c
+++ b/arch/arm/mach-omap2/common.c
@@ -33,5 +33,7 @@ void __init omap_reserve(void)
 	omap_dsp_reserve_sdram_memblock();
 	omap_secure_ram_reserve_memblock();
 	omap_barrier_reserve_memblock();
+#ifdef CONFIG_OMAP_VRFB
 	omap_fb_reserve_memblock();
+#endif
 }


### PR DESCRIPTION
This fixes

```
arch/arm/mach-omap2/built-in.o: In function `omap_reserve': /data/l/linux-n900/arch/arm/mach-omap2/common.c:36: undefined reference to `omap_fb_reserve_memblock'
```
